### PR TITLE
read token files as binary and decode to latin-1

### DIFF
--- a/pysentiment/utils.py
+++ b/pysentiment/utils.py
@@ -52,8 +52,9 @@ class Tokenizer(BaseTokenizer):
                  'Names.txt']
         stopset = set()
         for f in files:
-            fin = open('%s/%s'%(STATIC_PATH, f))
+            fin = open('%s/%s'%(STATIC_PATH, f), 'rb')
             for line in fin.readlines():
+                line = line.decode(encoding='latin-1')
                 match = re.search('(\w+)', line)
                 if match == None:
                     continue


### PR DESCRIPTION
in order to maintain compatibility with Python 3 string handling.

With this commit pysentiment works well with NLTK 3 alpha releases http://nltk.org/nltk3-alpha/, which provide Python 3 support.
